### PR TITLE
Pivot project to gaming news sources

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,22 +1,23 @@
-
+.RECIPEPREFIX := >
 .PHONY: install fetch summarize render push all clean
 
 install:
-\tpip install -r requirements.txt
+>pip install -r requirements.txt
 
 fetch:
-\tpython -m scripts.run_all --step fetch
+>python -m scripts.run_all --step fetch
 
 summarize:
-\tpython -m scripts.run_all --step summarize
+>python -m scripts.run_all --step summarize
 
 render:
-\tpython -m scripts.run_all --step render
+>python -m scripts.run_all --step render
 
 push:
-\tpython -m scripts.run_all --step push
+>python -m scripts.run_all --step push
 
 all: install fetch summarize render push
 
 clean:
-\trm -rf out/*.md
+>rm -rf out/*.md
+

--- a/intl_news/config.py
+++ b/intl_news/config.py
@@ -6,29 +6,33 @@ JST_TZ = "Asia/Tokyo"
 
 # Reputable sources (RSS)
 FEEDS: Dict[str, str] = {
-    "Reuters World": "https://www.reuters.com/world/rss",
-    "BBC World": "http://feeds.bbci.co.uk/news/world/rss.xml",
-    "The Guardian World": "https://www.theguardian.com/world/rss",
-    "Al Jazeera Top": "https://www.aljazeera.com/xml/rss/all.xml",
+    "IGN": "https://feeds.ign.com/ign/all",
+    "GameSpot": "https://www.gamespot.com/feeds/news/",
+    "Polygon": "https://www.polygon.com/rss/index.xml",
+    "Eurogamer": "https://www.eurogamer.net/feed",
+    "PC Gamer": "https://www.pcgamer.com/rss/",
+    "Rock Paper Shotgun": "https://www.rockpapershotgun.com/feed",
+    "The Verge Games": "https://www.theverge.com/games/rss/index.xml",
+    "Dot Esports": "https://dotesports.com/feed",
+    "HLTV": "https://www.hltv.org/rss/news",
+    "PlayStation Blog": "https://blog.playstation.com/feed/",
+    "Xbox Wire": "https://news.xbox.com/en-us/feed/",
+    "Nintendo News": "https://www.nintendo.com/whatsnew/feed",
+    "Steam News": "https://store.steampowered.com/feeds/news.xml",
+    "PocketGamer.biz": "https://www.pocketgamer.biz/rss/",
 }
 
 # Simple region/topic tagging by keyword
 TAGS = [
-    ("【中东】", ["Gaza","Israel","Hamas","Lebanon","Iran","Iraq","Syria","Middle East","Gulf"]),
-    ("【欧洲】", ["EU","Europe","European","Germany","France","UK","Britain","Ukraine","Russia","NATO","Belarus","Poland"]),
-    ("【美洲】", ["United States","US ","U.S.","Mexico","Brazil","Argentina","Venezuela","Canada","Caribbean"]),
-    ("【亚洲】", ["China","Beijing","Japan","Tokyo","Korea","Seoul","India","South Asia","Pakistan","Philippines","Indonesia","Malaysia","Singapore","Hong Kong","Taiwan","Vietnam","Thailand"]),
-    ("【非洲】", ["Africa","Kenya","Nigeria","South Africa","Ethiopia","Sudan","Congo"]),
-    ("【市场】", ["stocks","bonds","yields","equities","markets","gold","oil","WTI","Brent","inflation","rate","Fed","ECB"]),
-    ("【科技】", ["AI","tech","technology","Google","Apple","Microsoft","chip","semiconductor","OpenAI","Nvidia","Meta","TikTok","X ","Twitter"]),
-    ("【气候】", ["climate","heatwave","storm","hurricane","typhoon","La Nina","El Nino","flood","wildfire","drought","WMO"]),
-    ("【人道/灾害】", ["earthquake","quake","landslide","famine","epidemic","outbreak","tsunami","death toll","casualties"]),
-    ("【冲突/安全】", ["war","conflict","missile","drone","attack","strike","ceasefire","military","troops","army","navy"]),
+    ("【发售/延期】", ["release","launch","launches","delayed","delay","postponed","out now","coming"]),
+    ("【更新/补丁】", ["update","patch","version","dlc","season","hotfix"]),
+    ("【电竞】", ["esports","tournament","league","championship","match","roster","team"]),
+    ("【行业/资本】", ["acquire","acquisition","merger","funding","investment","revenue","earnings","IPO","market"]),
 ]
 
 # Keywords to flag "breaking"
 BREAKING_HINTS = [
-    "earthquake","blast","explosion","killed","death toll","state of emergency","magnitude","7.0","evacuate","ceasefire collapses","strike kills",
+    "launch","release","delay","delayed","patch","update","tournament","championship","acquisition","funding",
 ]
 
 MAX_ITEMS = 8

--- a/intl_news/render.py
+++ b/intl_news/render.py
@@ -5,7 +5,7 @@ from zoneinfo import ZoneInfo
 
 JST = ZoneInfo("Asia/Tokyo")
 
-HEADER_TMPL = "1) 今日国际新闻简报（JST 日期：{date})\n"
+HEADER_TMPL = "1) 今日游戏资讯简报（JST 日期：{date})\n"
 
 def render_brief(items: List[Dict[str, Any]]) -> str:
     today = datetime.now(JST).strftime("%Y-%m-%d")
@@ -35,28 +35,28 @@ def render_tiktok(items: List[Dict[str, Any]]) -> str:
     lines.append("2) 抖音短视频逐字稿（45–60 秒）\n")
     # Hook
     lines.append("- Hook（0–3s）  ")
-    lines.append(f"口播：今天关键词——{today_kw}。  ")
+    lines.append(f"口播：今天游戏圈关键词——{today_kw}。  ")
     lines.append(f"屏幕大字：{today_kw.replace('、','｜')}  ")
-    lines.append("B-roll：地球卫星→世界城市群快切  ")
+    lines.append("B-roll：主机、PC、手游游戏画面快切  ")
     lines.append("SFX：轻击+上扬提示音\n")
     # Quick takes
     for i, it in enumerate(top4, start=1):
         lines.append(f"- 快讯{i}（{3+ (i-1)*11}–{3+i*11}s）  ")
         lines.append(f"口播：{it['summary_zh']}  ")
-        lines.append(f"屏幕大字：{it['tag'].strip('【】')}要闻  ")
-        lines.append("B-roll：新闻相关的远景或抽象素材（避免血腥/敏感特写）  ")
+        lines.append(f"屏幕大字：{it['tag'].strip('【】')}快讯  ")
+        lines.append("B-roll：相关游戏实机、预告或电竞镜头（避免剧透/不当内容）  ")
         lines.append("转场SFX：whoosh\n")
     # Wrap + CTA
     lines.append("- Wrap（45–55s）  ")
-    lines.append("口播：以上是今日全球脉络，事件或有更新，以权威来源为准。  ")
+    lines.append("口播：以上是今日游戏动态，信息或有更新，以官方渠道为准。  ")
     lines.append("屏幕大字：信息随时更新\n")
     lines.append("- CTA（55–60s）  ")
-    lines.append("口播：关注我，60秒掌握全球。  ")
+    lines.append("口播：关注我，60秒掌握游戏圈。  ")
     lines.append("屏幕大字：关注｜收藏\n")
     # Extras
-    lines.append("封面标题（≤14字）：今日全球要闻速览")
-    lines.append("视频说明/Caption（≤80字）：一分钟看全球：精选权威媒体要闻，信息随时更新，详见来源。")
-    lines.append("话题标签：#国际新闻 #早报 #今日热点 #财经 #科技 #地缘政治 #欧洲 #中东 #市场 #气候")
+    lines.append("封面标题（≤14字）：今日游戏资讯速览")
+    lines.append("视频说明/Caption（≤80字）：一分钟看游戏圈：精选主机、PC、手游与电竞动态，更多详见来源。")
+    lines.append("话题标签：#游戏资讯 #主机游戏 #PC游戏 #手游 #电竞")
     return "\n".join(lines)
 
 def render_sources(items: List[Dict[str, Any]]) -> str:


### PR DESCRIPTION
## Summary
- Switch RSS sources to major gaming outlets and retune tagging/breaking keywords for releases, updates, esports and industry news.
- Rename brief and TikTok script to focus on gaming, adjusting B-roll and copy for console/PC/mobile/esports contexts.
- Fix Makefile and verify `make all` generates `out/brief_JST.md` and `out/tiktok_script.md`.

## Testing
- `make all`

## Further Work
- Expand feeds with regional sites such as 4Gamer or Famitsu.
- Add similarity-based deduplication to avoid repeated stories across feeds.


------
https://chatgpt.com/codex/tasks/task_e_68b84d716a5c832b98c003c2ff2df471